### PR TITLE
dockerfile: use image from swi-prolog community

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,10 @@
-FROM ubuntu:20.04
+FROM swipl:8.4.2
 
 RUN apt-get update && \
-    apt-get install -y jq software-properties-common && \
-    apt-add-repository ppa:swi-prolog/stable && \
-    apt-get update && \
-    apt-get install -y swi-prolog && \
+    apt-get install -y jq && \
     apt-get purge --auto-remove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
 
 COPY . /opt/test-runner
 WORKDIR /opt/test-runner


### PR DESCRIPTION
See #27 and #26

With changing version for builds in `swipl` ppa - it's a pain to keep up with the ever changing expected output.
Here I use a docker image from SWI-Prolog community -
See https://hub.docker.com/_/swipl?tab=description

Original Dockerfile is based on `bullseye-slim` a much smaller image - quicker builds.
https://github.com/SWI-Prolog/docker-swipl/blob/master/8.4.2/bullseye/Dockerfile

Right now the tests pass locally for me. Its a change in terms of functionality - Lets discuss.
```bash
[prolog-test-runner] ./bin/run-tests-in-docker.sh
Sending build context to Docker daemon  54.78kB
Step 1/5 : FROM swipl:8.4.2
 ---> bf0310c1f919
Step 2/5 : RUN apt-get update &&     apt-get install -y jq &&     apt-get purge --auto-remove &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> bad2783c0ca3
Step 3/5 : COPY . /opt/test-runner
 ---> Using cache
 ---> 54b6557008dc
Step 4/5 : WORKDIR /opt/test-runner
 ---> Using cache
 ---> 82ec989c89ad
Step 5/5 : ENTRYPOINT ["/opt/test-runner/bin/run.sh"]
 ---> Using cache
 ---> 147213b5ae6d
Successfully built 147213b5ae6d
Successfully tagged exercism/prolog-test-runner:latest
example-all-fail: testing...
example-all-fail: done
example-all-fail: comparing results.json to expected_results.json
example-empty-file: testing...
example-empty-file: done
example-empty-file: comparing results.json to expected_results.json
example-partial-fail: testing...
example-partial-fail: done
example-partial-fail: comparing results.json to expected_results.json
example-success: testing...
example-success: done
example-success: comparing results.json to expected_results.json
example-syntax-error: testing...
example-syntax-error: done
example-syntax-error: comparing results.json to expected_results.json
```